### PR TITLE
Trusted source

### DIFF
--- a/infrastructure-plan/features/sg.feature
+++ b/infrastructure-plan/features/sg.feature
@@ -14,7 +14,7 @@ Feature: Security Group Standards AWS
         Then it must have ingress
         Then it must not have <proto> protocol and port <portNumber> for 0.0.0.0/0
 
-    Examples:
+        Examples:
         | ProtocolName | proto | portNumber |
         | HTTP         | tcp   | 443        |
         | Telnet       | tcp   | 23         |

--- a/infrastructure-plan/features/stack.feature
+++ b/infrastructure-plan/features/stack.feature
@@ -1,0 +1,14 @@
+Feature: Infrastructure Sources
+
+    Scenario Outline: Ensure our infrastructure comes from a trusted source.
+        Given I have a resource defined
+        Then its name must match the "^(stack|module)" regex
+        When its name is <name>
+        Then it must contain source
+        And its value must match the <pattern> regex
+
+        Examples:
+        | name   | pattern                                   |
+        | stack  | mygainwell\/acuity-aws-stacks\.git        |
+        | module | mygainwell\/acuity-terraform-modules\.git |
+        | module | gruntwork-io\/.*\.git                     |


### PR DESCRIPTION
This will let us enforce that we only deploy code that is from our `acuity-aws-stacks` or `acuity-terraform-modules` or `gruntwork-io` when running any actions. 