### PR TITLE
Terragrunt: run-all apply

### DIFF
--- a/terragrunt-action/src/main.sh
+++ b/terragrunt-action/src/main.sh
@@ -159,6 +159,7 @@ function main {
     source ${scriptDir}/terragrunt_validate.sh
     source ${scriptDir}/terragrunt_plan.sh
     source ${scriptDir}/terragrunt_apply.sh
+    source ${scriptDir}/terragrunt_apply_run_all.sh
     source ${scriptDir}/terragrunt_output.sh
     source ${scriptDir}/terragrunt_import.sh
     source ${scriptDir}/terragrunt_taint.sh
@@ -171,7 +172,7 @@ function main {
     installTerragrunt
 
     cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
-    
+    echo "${tfSubcommand}"
     case "${tfSubcommand}" in
         init)
             echo "::group::init"
@@ -193,6 +194,11 @@ function main {
             terragruntApply ${*}
             echo "::endgroup::"
         ;;
+        apply-all)
+            echo "::group::apply-all"
+            terragruntApplyRunAll ${*}
+            echo "::endgroup::"
+        ;;        
         output)
             echo "::group::output"
             terragruntOutput ${*}

--- a/terragrunt-action/src/terragrunt_apply.sh
+++ b/terragrunt-action/src/terragrunt_apply.sh
@@ -3,7 +3,7 @@
 function terragruntApply {
     # Gather the output of `terragrunt apply`.
     echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
-    applyOutput=$(${tfBinary} run-all apply -auto-approve -input=false ${*} 2>&1)
+    applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
     applyExitCode=${?}
     applyCommentStatus="Failed"
     

--- a/terragrunt-action/src/terragrunt_apply.sh
+++ b/terragrunt-action/src/terragrunt_apply.sh
@@ -3,7 +3,7 @@
 function terragruntApply {
     # Gather the output of `terragrunt apply`.
     echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
-    applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
+    applyOutput=$(${tfBinary} run-all apply -auto-approve -input=false ${*} 2>&1)
     applyExitCode=${?}
     applyCommentStatus="Failed"
     

--- a/terragrunt-action/src/terragrunt_apply_run_all.sh
+++ b/terragrunt-action/src/terragrunt_apply_run_all.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function terragruntApplyRunAll {
+    # Gather the output of `terragrunt apply`.
+    echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
+    applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
+    applyExitCode=${?}
+    applyCommentStatus="Failed"
+    
+    # Exit code of 0 indicates success. Print the output and exit.
+    if [ ${applyExitCode} -eq 0 ]; then
+        echo "apply: info: successfully applied Terragrunt configuration in ${tfWorkingDir}"
+        echo "${applyOutput}"
+        echo
+        applyCommentStatus="Success"
+    fi
+    
+    # Exit code of !0 indicates failure.
+    if [ ${applyExitCode} -ne 0 ]; then
+        echo "apply: error: failed to apply Terragrunt configuration in ${tfWorkingDir}"
+        echo "${applyOutput}"
+        echo
+    fi
+    
+    exit ${applyExitCode}
+}

--- a/terragrunt-action/src/terragrunt_apply_run_all.sh
+++ b/terragrunt-action/src/terragrunt_apply_run_all.sh
@@ -4,7 +4,7 @@ function terragruntApplyRunAll {
     echo $(ls)
     # Gather the output of `terragrunt apply`.
     echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
-    applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
+    applyOutput=$(${tfBinary} run-all apply -auto-approve -input=false ${*} 2>&1)
     applyExitCode=${?}
     applyCommentStatus="Failed"
     

--- a/terragrunt-action/src/terragrunt_apply_run_all.sh
+++ b/terragrunt-action/src/terragrunt_apply_run_all.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function terragruntApplyRunAll {
+    echo $(ls)
     # Gather the output of `terragrunt apply`.
     echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
     applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)

--- a/terragrunt-action/src/terragrunt_apply_run_all.sh
+++ b/terragrunt-action/src/terragrunt_apply_run_all.sh
@@ -4,7 +4,7 @@ function terragruntApplyRunAll {
     echo $(ls)
     # Gather the output of `terragrunt apply`.
     echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
-    applyOutput=$(${tfBinary} run-all apply -auto-approve -input=false ${*} 2>&1)
+    applyOutput=$(${tfBinary} run-all apply --terragrunt-non-interactive -input=false ${*} 2>&1)
     applyExitCode=${?}
     applyCommentStatus="Failed"
     


### PR DESCRIPTION
New terragrunt sub command support to execute a `run-all apply` from the defined path.

[Terragrunt - run-all command](https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#the-run-all-command)